### PR TITLE
change repodelete.py auth from username/password to personal access token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 #pickles folder
 /pickles
 
+# config.ini has a github PAT
+config.ini
+
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+requests = "*"
+
+[requires]
+python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,59 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "acbc8c4e7f2f98f1059b2a93d581ef43f4aa0c9741e64e6253adff8e35fbd99e"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
+            ],
+            "version": "==2020.6.20"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
+                "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
+            ],
+            "index": "pypi",
+            "version": "==2.24.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
+                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.25.10"
+        }
+    },
+    "develop": {}
+}

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,3 +1,4 @@
 [Github]
 # must have delete_repo and public_repo scopes
+# https://github.com/settings/tokens/new
 PersonalAccessToken = __YOUR_PAT_HERE__

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,0 +1,3 @@
+[Github]
+# must have delete_repo and public_repo scopes
+PersonalAccessToken = __YOUR_PAT_HERE__

--- a/repodelete.py
+++ b/repodelete.py
@@ -45,7 +45,7 @@ def prompt_for_org_info():
     while not org:
         org = input("Github Org: ")
 
-    return org
+    return org.strip()
 
 
 def load_token():

--- a/repodelete.py
+++ b/repodelete.py
@@ -2,39 +2,68 @@
 # thank you Andy
 import requests
 import getpass
+import configparser
 
-GITHUB_GET_REPOS_API = 'https://api.github.com/orgs/{}/repos'
-GITHUB_REPO_API = 'https://api.github.com/repos/{}'
-
-
-def get_all_repos(org, username, password):
-    return requests.get(GITHUB_GET_REPOS_API.format(org), auth=(username, password)).json()
+GITHUB_GET_REPOS_API = "https://api.github.com/orgs/{}/repos"
+GITHUB_REPO_API = "https://api.github.com/repos/{}"
+CONFIG_FILE = "config.ini"
 
 
-def delete_repo(repo_name, username, password):
-    requests.delete(GITHUB_REPO_API.format(repo_name), auth=(username, password))
+def get_all_repos(org, token):
+    return requests.get(GITHUB_GET_REPOS_API.format(org), headers=headers(token)).json()
 
 
-def delete_repos(repo_names, username, password):
+def delete_repo(repo_name, token):
+    res = requests.delete(GITHUB_REPO_API.format(repo_name), headers=headers(token))
+    if res.status_code < 200 or res.status_code > 300:
+        print(f"ERROR: Delete failed for {repo_name}")
+        print(res.json())
+        raise Exception(f"ERROR: Delete failed for {repo_name}")
+
+
+def delete_repos(repo_names, token):
     for repo_name in repo_names:
-        print(f'Deleting {repo_name}...')
-        delete_repo(repo_name, username, password)
+        print(f"Deleting {repo_name}...")
+        delete_repo(repo_name, token)
+
+
+def headers(token):
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github.inertia-preview+json",
+        "User-Agent": "repodelete",
+    }
 
 
 def diff_lists(list1, list2):
-    upper_list2 = [ el.upper() for el in list2 ]
-    return [ el for el in list1 if el.upper() not in upper_list2 ]
+    upper_list2 = [el.upper() for el in list2]
+    return [el for el in list1 if el.upper() not in upper_list2]
 
 
-def prompt_for_user_info():
-    org = input('Github Org: ')
-    username = input('Github Username: ')
-    password = getpass.getpass('Github Password: ')
-    return (org, username, password)
+def prompt_for_org_info():
+    org = input("Github Org: ")
+    while not org:
+        org = input("Github Org: ")
+
+    return org
+
+
+def load_token():
+    config = configparser.ConfigParser()
+    config.read(CONFIG_FILE)
+    try:
+        token = config["Github"]["PersonalAccessToken"].strip()
+        if token == "":
+            raise ValueError()
+        print(f"Found Github Personal Access Token in {CONFIG_FILE}")
+        return token
+    except:
+        print("ERROR: Unable to load Github Personal Access Token from {CONFIG_FILE}")
+        raise
 
 
 def prompt_for_repos_to_keep():
-    print('Enter the repos to keep. (one per line, enter a blank line when done)')
+    print("Enter the repos to keep. (one per line, enter a blank line when done)")
 
     repos_to_keep = []
     repo = input()
@@ -45,25 +74,27 @@ def prompt_for_repos_to_keep():
     return repos_to_keep
 
 
-if __name__ == '__main__':
-    org, username, password = prompt_for_user_info()
+if __name__ == "__main__":
+    org = prompt_for_org_info()
+    token = load_token()
 
-    repos = get_all_repos(org, username, password)
-    #print(repos)
-    full_names = [ repo['full_name'] for repo in repos ]
+    repos = get_all_repos(org, token)
+    full_names = [repo["full_name"] for repo in repos]
 
-    print('Found the following repos:')
-    print('\n'.join(full_names))
+    print("Found the following repos:")
+    print("\n".join(full_names))
 
-    keep_names = [ f'{org}/{name}' if '/' not in name else name
-                   for name in prompt_for_repos_to_keep() ]
+    keep_names = [
+        f"{org}/{name}" if "/" not in name else name
+        for name in prompt_for_repos_to_keep()
+    ]
 
     delete_names = diff_lists(full_names, keep_names)
 
-    print('The following repos will be PERMENANTLY deleted.')
-    print('\n'.join(delete_names))
-    confirm = input('Do you wish to proceed? (yes/no)')
-    if confirm != 'yes':
-        print('...probably a wise choice.')
+    print("The following repos will be PERMENANTLY deleted.")
+    print("\n".join(delete_names))
+    confirm = input("Do you wish to proceed? (yes/no)")
+    if confirm != "yes":
+        print("...probably a wise choice.")
     else:
-        delete_repos(delete_names, username, password)
+        delete_repos(delete_names, token)


### PR DESCRIPTION
Note this change depends on a `config.ini` file that provides the github PAT. Since it's a no-no to put tokens in public repos the `config.ini` file has been added to the `.gitignore`, but there's a example that should be self explanatory.

I also added `.vscode` to the `.gitignore` so you wouldn't be burdened with my vs code configuration.

Finally, there's a `Pipfile` that is suitable to use in a `pipenv` virtual environment.